### PR TITLE
fixing build error useSearchParams() should be wrapped in a suspense boundary at page "/".

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,16 @@
-import React from "react";
+import React, { Suspense } from "react";
 import { TranscriptProvider } from "@/app/contexts/TranscriptContext";
 import { EventProvider } from "@/app/contexts/EventContext";
 import App from "./App";
 
 export default function Page() {
   return (
-    <TranscriptProvider>
-      <EventProvider>
-        <App />
-      </EventProvider>
-    </TranscriptProvider>
+    <Suspense fallback={<div>Loading...</div>}>
+      <TranscriptProvider>
+        <EventProvider>
+          <App />
+        </EventProvider>
+      </TranscriptProvider>
+    </Suspense>
   );
 }


### PR DESCRIPTION
Fixing the npm build error by Update page.tsx to include Suspense