### PR TITLE
Wait until the output_audio_buffer is empty

### DIFF
--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -65,6 +65,7 @@ export interface Log {
 export interface ServerEvent {
   type: string;
   event_id?: string;
+  response_id?: string;
   item_id?: string;
   transcript?: string;
   delta?: string;


### PR DESCRIPTION
# Situation

- When two responses are generated by the model in a short time, the second response is sometimes not played back in audio 
- This happens when the first response is long. While the first response is being played back, the second response is generated. The `output_audio_buffer` is created only for the first response and not for the second response.
- In this repo, I encountered the error in the `customerServiceRetail` scenario. When I am transferred from the `authentication` agent to the `return` agent, I could hear the line from the former but not the latter

# Proposed solution

- Wait to send a client event `response.create` or to transfer agents in function calls until all output_audio_buffers are cleared. Responses will not be created until all preceding responses are played back.