### PR TITLE
Fix: text-only mode returning empty responses

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -248,8 +248,11 @@ function App() {
 
     const sessionConfig = {
       modalities: ["text"],
+      input_audio_format: "pcm16",
+      input_audio_transcription: { model: "whisper-1" },
       instructions,
       tools,
+      turn_detection: turnDetection,
     };
 
 
@@ -257,10 +260,7 @@ function App() {
       sessionConfig.modalities.push("audio"); // Changing this to "text" will disable audio
       Object.assign(sessionConfig, {
         voice: "coral",
-        input_audio_format: "pcm16",
         output_audio_format: "pcm16",
-        input_audio_transcription: { model: "whisper-1" },
-        turn_detection: turnDetection,
       });
     }
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -245,18 +245,28 @@ function App() {
     const instructions = currentAgent?.instructions || "";
     const tools = currentAgent?.tools || [];
 
-    const sessionUpdateEvent = {
-      type: "session.update",
-      session: {
-        modalities: ["text", "audio"],
-        instructions,
+
+    const sessionConfig = {
+      modalities: ["text"],
+      instructions,
+      tools,
+    };
+
+
+    if (isAudioPlaybackEnabled) {
+      sessionConfig.modalities.push("audio"); // Changing this to "text" will disable audio
+      Object.assign(sessionConfig, {
         voice: "coral",
         input_audio_format: "pcm16",
         output_audio_format: "pcm16",
         input_audio_transcription: { model: "whisper-1" },
         turn_detection: turnDetection,
-        tools,
-      },
+      });
+    }
+
+    const sessionUpdateEvent = {
+      type: "session.update",
+      session: sessionConfig,
     };
 
     sendClientEvent(sessionUpdateEvent);

--- a/src/app/hooks/useHandleServerEvent.ts
+++ b/src/app/hooks/useHandleServerEvent.ts
@@ -139,6 +139,16 @@ export function useHandleServerEvent({
         break;
       }
 
+      case "conversation.item.text.delta":
+      case "response.text.delta": {
+        const itemId = serverEvent.item_id;
+        const deltaText = serverEvent.delta || "";
+        if (itemId) {
+          updateTranscriptMessage(itemId, deltaText, true);
+        }
+        break;
+      }
+
       case "conversation.item.input_audio_transcription.completed": {
         const itemId = serverEvent.item_id;
         const finalTranscript =


### PR DESCRIPTION
This pull request resolves the issue where the text-only mode was returning **empty** responses from the server.

While the solution suggested by the issue's author is functional, this PR offers a more better and efficient approach.

ISSUE: [https://github.com/openai/openai-realtime-agents/issues/32](https://github.com/openai/openai-realtime-agents/issues/32)

Testing:
1. Forked and Cloned the repository, then followed the steps to reproduce the issue.
2. Verified that the responses in text-only mode now correctly contain the expected text content instead of being empty.