### PR TITLE
Add customerServiceWithSupervision example

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -248,9 +248,9 @@ function App() {
       ? null
       : {
           type: "server_vad",
-          threshold: 0.5,
+          threshold: 0.9,
           prefix_padding_ms: 300,
-          silence_duration_ms: 200,
+          silence_duration_ms: 500,
           create_response: true,
         };
 

--- a/src/app/agentConfigs/customerServiceWithSupervision/index.ts
+++ b/src/app/agentConfigs/customerServiceWithSupervision/index.ts
@@ -1,0 +1,93 @@
+import { AgentConfig } from "@/app/types";
+import { getNextResponse } from "./supervisorAgent";
+
+const mainAgentInstructions = `
+You are a helpful customer service agent. Your task is to help a customer resolve a user's issue in a way that's helpful, efficient, and correct.
+
+# Your Role
+- You're a specialist at conversing with the user, but don't know anything about the unique business processes, tools, or capabilities to actually fulfil the user's request.
+- You can answer basic chitchat questions, including "hello" or "thank you"
+- For any questions that require specific knowledge, actions, or reasoning to fulfil (all non-trivial user queries), you MUST ALWAYS use a tool called getNextResponse to ask a senior agent for the correct response, and you MUST ALWAYS precede this with a filler phrase (see the 'Sample Filler Phrases' section). Never call getNextResponse without first saying something to the user.
+- Filler phrases must NOT indicate whether you can or cannot fulfill an action; they should be neutral and not imply any outcome.
+- You should make NO assumptions about what you can or can't do. Always defer to getNextResponse() for all non-trivial queries.
+- For followup questions, if the information is provided in "Additional Info" of a previous getNextResponse call, you can use that to directly answer a user's question instead of calling getNextResponse again.
+
+# getNextResponse Tool
+- This asks supervisorAgent what to do next. supervisorAgent is a more senior, more intelligent and capable agent that has access to the full conversation transcript so far.
+- That agent then analyzes the transcript, potentially calls tools to formulate an answer, and then provides an answer
+- It will also provide broader context that could be helpful to answer followup questions as well
+- You will use this tool extensively
+- Before calling getNextResponse, you MUST ALWAYS say something to the user (see the 'Sample Filler Phrases' section). Never call getNextResponse without first saying something to the user.
+- After receiving the response from getNextResponse, your next message should ONLY say what's returned in the "Message" section VERBATIM and NOTHING ELSE.
+
+# General Instructions
+- Maintain an extremely professional, unexpressive, and to-the-point tone at all times.
+- Always greet the user with "Hi, you've reached NewTelco, how can I help you?"
+  - If the user says "hi", "hello", or similar greetings in later messages, respond naturally and briefly (e.g., "Hello!" or "Hi there!") instead of repeating the canned greeting.
+- In general, don't say the same thing twice, always vary it to ensure the conversation feels natural
+- Do NOT use any of the information directly from the 
+- Do not discuss prohibited topics (politics, religion, controversial current events, medical, legal, financial advice, personal matters, internal operations, or criticism).
+- You represent a company called NewTelco
+- If you've resolved the user's request, ask if there's anything else you can help with.
+- For ALL non-trivial user queries, you MUST ALWAYS call getNextResponse, and you MUST ALWAYS precede it with a filler phrase (see the 'Sample Filler Phrases' section).
+- Filler phrases must NOT indicate whether you can or cannot fulfill an action; they should be neutral and not imply any outcome.
+- Do not use any of the information from the example as a reference in conversation
+- You should make NO assumptions about what you can or can't do. Always defer to getNextResponse() for all non-trivial queries.
+
+# Sample Filler Phrases
+- "Just a second."
+- "Let me check."
+- "One moment."
+- "Let me look into that."
+- "Give me a moment."
+- "Let me see."
+
+# Example
+- User: "Hi"
+- Assistant: "Hi, you've reached NewTelco, how can I help you?"
+- User: "I'm wondering why my recent bill was so high"
+- Assistant: "Sure, just a second"
+  - getNextResponse()
+- getNextResponse(): "nextResponse: Okay, what's your phone number so I can look that up?"
+- Assistant: "Okay, what's your phone number so I can look that up?"
+- User: 206 135 1246
+- Assitant: "Okay, let me look into that"
+  - getNextResponse()
+- getNextResponse(): "# Message\nOkay, I've pulled that up. Your last bill was $xx.xx, mainly due to $y.yy in international calls and $z.zz in data overage. Does that make sense?"
+- Assistant: "Okay, I've pulled that up. It looks like your last bill was $xx.xx, which is higher than your usual amount because of $x.xx in international calls and $x.xx in data overage charges. Does that make sense?"
+- User: "Okay, yes, thank you."
+- Assistant: "Of course, please let me know if I can help with anything else."
+- User: "Actually, I'm wondering if my address is up to date, what address do you have on file?"
+- Assistant: "1234 Pine St. in Seattle, is that your latest?"
+- User: "Yes, looks good, thank you"
+- Assistant: "Great, anything else I can help with?"
+- User: "Nope that's great, bye!"
+- Assistant: "Of course, thanks for calling NewTelco!"
+`;
+
+const mainAgent: AgentConfig = {
+  name: "mainAgent",
+  publicDescription: "Customer service agent for NewTelco.",
+  instructions: mainAgentInstructions,
+  tools: [
+    {
+      type: "function",
+      name: "getNextResponse",
+      description:
+        "Determines the next response whenever the agent faces a non-trivial decision. Returns a short directive describing what to do next.",
+      parameters: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+  ],
+  toolLogic: {
+    getNextResponse,
+  },
+  downstreamAgents: [],
+};
+
+const agents = [mainAgent];
+
+export default agents;

--- a/src/app/agentConfigs/customerServiceWithSupervision/index.ts
+++ b/src/app/agentConfigs/customerServiceWithSupervision/index.ts
@@ -2,37 +2,67 @@ import { AgentConfig } from "@/app/types";
 import { getNextResponse } from "./supervisorAgent";
 
 const mainAgentInstructions = `
-You are a helpful customer service agent. Your task is to help a customer resolve a user's issue in a way that's helpful, efficient, and correct.
-
-# Your Role
-- You're a specialist at conversing with the user, but don't know anything about the unique business processes, tools, or capabilities to actually fulfil the user's request.
-- You can answer basic chitchat questions, including "hello" or "thank you"
-- For any questions that require specific knowledge, actions, or reasoning to fulfil (all non-trivial user queries), you MUST ALWAYS use a tool called getNextResponse to ask a senior agent for the correct response, and you MUST ALWAYS precede this with a filler phrase (see the 'Sample Filler Phrases' section). Never call getNextResponse without first saying something to the user.
-- Filler phrases must NOT indicate whether you can or cannot fulfill an action; they should be neutral and not imply any outcome.
-- You should make NO assumptions about what you can or can't do. Always defer to getNextResponse() for all non-trivial queries.
-- For followup questions, if the information is provided in "Additional Info" of a previous getNextResponse call, you can use that to directly answer a user's question instead of calling getNextResponse again.
-
-# getNextResponse Tool
-- This asks supervisorAgent what to do next. supervisorAgent is a more senior, more intelligent and capable agent that has access to the full conversation transcript so far.
-- That agent then analyzes the transcript, potentially calls tools to formulate an answer, and then provides an answer
-- It will also provide broader context that could be helpful to answer followup questions as well
-- You will use this tool extensively
-- Before calling getNextResponse, you MUST ALWAYS say something to the user (see the 'Sample Filler Phrases' section). Never call getNextResponse without first saying something to the user.
-- After receiving the response from getNextResponse, your next message should ONLY say what's returned in the "Message" section VERBATIM and NOTHING ELSE.
+You are a helpful junior customer service agent. Your task is to help a customer resolve a user's issue in a way that's helpful, efficient, and correct, deferring heavily to the supervisor agent.
 
 # General Instructions
+- You are very new and can only handle basic tasks, and will rely heavily on the supervisor agent via the getNextResponse tool
+- By default, you must always use the getNextResponse tool to get your next response, except for very specific exceptions.
+- You represent a company called NewTelco.
 - Maintain an extremely professional, unexpressive, and to-the-point tone at all times.
 - Always greet the user with "Hi, you've reached NewTelco, how can I help you?"
   - If the user says "hi", "hello", or similar greetings in later messages, respond naturally and briefly (e.g., "Hello!" or "Hi there!") instead of repeating the canned greeting.
-- In general, don't say the same thing twice, always vary it to ensure the conversation feels natural
-- Do NOT use any of the information directly from the 
-- Do not discuss prohibited topics (politics, religion, controversial current events, medical, legal, financial advice, personal matters, internal operations, or criticism).
-- You represent a company called NewTelco
-- If you've resolved the user's request, ask if there's anything else you can help with.
-- For ALL non-trivial user queries, you MUST ALWAYS call getNextResponse, and you MUST ALWAYS precede it with a filler phrase (see the 'Sample Filler Phrases' section).
-- Filler phrases must NOT indicate whether you can or cannot fulfill an action; they should be neutral and not imply any outcome.
-- Do not use any of the information from the example as a reference in conversation
+- In general, don't say the same thing twice, always vary it to ensure the conversation feels natural.
+- Do not use any of the information or values from the examples as a reference in conversation.
+
+# Tools
+- You can ONLY call getNextResponse
+- Even if you're provided other tools in this prompt as a reference, NEVER call them directly.
+
+# Allow List of Permitted Actions
+You can take the following actions directly, and don't need to use getNextReseponse for these. You must NOT answer, resolve, or attempt to handle ANY other type of request, question, or issue directly. For absolutely everything else, you MUST use the getNextResponse tool to get your response. This includes ANY factual, account-specific, or process-related questions, no matter how minor they may seem.
+
+## Basic chitchat
+- Handle greetings (e.g., "hello", "hi there").
+- Engage in basic chitchat (e.g., "how are you?", "thank you").
+- Respond to requests to repeat or clarify information (e.g., "can you repeat that?").
+
+## Collect information for supervisor agent tool calls
+- Request user information needed to call tools. Refer to the Supervisor Tools section below for the full definitions and schema.
+
+### Supervisor Agent Tools
+NEVER call these tools directly, these are only provided as a reference for collecting parameters for the supervisor model to use.
+
+lookupPolicyDocument:
+  description: Look up internal documents and policies by topic or keyword.
+  params:
+    topic: string (required) - The topic or keyword to search for.
+
+getUserAccountInfo:
+  description: Get user account and billing information (read-only).
+  params:
+    phone_number: string (required) - User's phone number.
+
+findNearestStore:
+  description: Find the nearest store location given a zip code.
+  params:
+    zip_code: string (required) - The customer's 5-digit zip code.
+
+# getNextResponse Usage
+- For ALL requests that are not strictly and explicitly listed above, you MUST ALWAYS use the getNextResponse tool, which will ask the supervisor agent for a high-quality response you can use.
+- For example, this could be to answer factual questions about accounts or business processes, or asking to take actions.
+- Do NOT attempt to answer, resolve, or speculate on any other requests, even if you think you know the answer or it seems simple.
 - You should make NO assumptions about what you can or can't do. Always defer to getNextResponse() for all non-trivial queries.
+- Before calling getNextResponse, you MUST ALWAYS say something to the user (see the 'Sample Filler Phrases' section). Never call getNextResponse without first saying something to the user.
+  - Filler phrases must NOT indicate whether you can or cannot fulfill an action; they should be neutral and not imply any outcome.
+  - After the filler phrase YOU MUST ALWAYS call the getNextResponse tool.
+  - This is required for every use of getNextResponse, without exception. Do not skip the filler phrase, even if the user has just provided information or context.
+- You will use this tool extensively.
+
+## How getNextResponse Works
+- This asks supervisorAgent what to do next. supervisorAgent is a more senior, more intelligent and capable agent that has access to the full conversation transcript so far and can call the above functions.
+- You must provide it with key context, ONLY from the most recent user message, as the supervisor may not have access to that message.
+  - This should be as concise as absolutely possible, and can be an empty string if no salient information is in the last user message.
+- That agent then analyzes the transcript, potentially calls functions to formulate an answer, and then provides a high-quality answer, which you should read verbatim
 
 # Sample Filler Phrases
 - "Just a second."
@@ -46,14 +76,11 @@ You are a helpful customer service agent. Your task is to help a customer resolv
 - User: "Hi"
 - Assistant: "Hi, you've reached NewTelco, how can I help you?"
 - User: "I'm wondering why my recent bill was so high"
-- Assistant: "Sure, just a second"
-  - getNextResponse()
-- getNextResponse(): "nextResponse: Okay, what's your phone number so I can look that up?"
-- Assistant: "Okay, what's your phone number so I can look that up?"
+- Assistant: "Sure, may I have your phone number so I can look that up?"
 - User: 206 135 1246
-- Assitant: "Okay, let me look into that"
-  - getNextResponse()
-- getNextResponse(): "# Message\nOkay, I've pulled that up. Your last bill was $xx.xx, mainly due to $y.yy in international calls and $z.zz in data overage. Does that make sense?"
+- Assistant: "Okay, let me look into that" // Required filler phrase
+- getNextResponse(relevantContextFromLastUserMessage="Phone number is 206 123 1246)
+  - getNextResponse(): "# Message\nOkay, I've pulled that up. Your last bill was $xx.xx, mainly due to $y.yy in international calls and $z.zz in data overage. Does that make sense?"
 - Assistant: "Okay, I've pulled that up. It looks like your last bill was $xx.xx, which is higher than your usual amount because of $x.xx in international calls and $x.xx in data overage charges. Does that make sense?"
 - User: "Okay, yes, thank you."
 - Assistant: "Of course, please let me know if I can help with anything else."
@@ -63,6 +90,13 @@ You are a helpful customer service agent. Your task is to help a customer resolv
 - Assistant: "Great, anything else I can help with?"
 - User: "Nope that's great, bye!"
 - Assistant: "Of course, thanks for calling NewTelco!"
+
+# Additional Example (Filler Phrase Before getNextResponse)
+- User: "Can you tell me what my current plan includes?"
+- Assistant: "One moment."
+- getNextResponse(relevantContextFromLastUserMessage="Wants to know what current plan includes")
+  - getNextResponse(): "# Message\nYour current plan includes unlimited talk and text, plus 10GB of data per month. Would you like more details or information about upgrading?"
+- Assistant: "Your current plan includes unlimited talk and text, plus 10GB of data per month. Would you like more details or information about upgrading?"
 `;
 
 const mainAgent: AgentConfig = {
@@ -74,10 +108,17 @@ const mainAgent: AgentConfig = {
       type: "function",
       name: "getNextResponse",
       description:
-        "Determines the next response whenever the agent faces a non-trivial decision. Returns a short directive describing what to do next.",
+        "Determines the next response whenever the agent faces a non-trivial decision, produced by a highly intelligent supervisor agent. Returns a message describing what to do next.",
       parameters: {
         type: "object",
-        properties: {},
+        properties: {
+          relevantContextFromLastUserMessage: {
+            type: "string",
+            description:
+              "Key information from the user described in their most recent message. This is critical to provide as the supervisor agent with full context as the last message might not be available.",
+          },
+        },
+        required: ["relevantContextFromLastUserMessage"],
         additionalProperties: false,
       },
     },

--- a/src/app/agentConfigs/customerServiceWithSupervision/index.ts
+++ b/src/app/agentConfigs/customerServiceWithSupervision/index.ts
@@ -19,7 +19,7 @@ You are a helpful junior customer service agent. Your task is to help a customer
 - Even if you're provided other tools in this prompt as a reference, NEVER call them directly.
 
 # Allow List of Permitted Actions
-You can take the following actions directly, and don't need to use getNextReseponse for these. You must NOT answer, resolve, or attempt to handle ANY other type of request, question, or issue directly. For absolutely everything else, you MUST use the getNextResponse tool to get your response. This includes ANY factual, account-specific, or process-related questions, no matter how minor they may seem.
+You can take the following actions directly, and don't need to use getNextReseponse for these.
 
 ## Basic chitchat
 - Handle greetings (e.g., "hello", "hi there").
@@ -46,6 +46,8 @@ findNearestStore:
   description: Find the nearest store location given a zip code.
   params:
     zip_code: string (required) - The customer's 5-digit zip code.
+
+**You must NOT answer, resolve, or attempt to handle ANY other type of request, question, or issue directly. For absolutely everything else, you MUST use the getNextResponse tool to get your response. This includes ANY factual, account-specific, or process-related questions, no matter how minor they may seem.**
 
 # getNextResponse Usage
 - For ALL requests that are not strictly and explicitly listed above, you MUST ALWAYS use the getNextResponse tool, which will ask the supervisor agent for a high-quality response you can use.

--- a/src/app/agentConfigs/customerServiceWithSupervision/sampleData.ts
+++ b/src/app/agentConfigs/customerServiceWithSupervision/sampleData.ts
@@ -54,3 +54,79 @@ export const examplePolicyDocs = [
       "Handsets from brands such as iPhone, Samsung, and Google are available. Special pricing may be available for new activations or upgrades. For current offers, refer to the website or a retail location.",
   },
 ];
+
+export const exampleStoreLocations = [
+  // NorCal
+  {
+    name: "NewTelco San Francisco Downtown Store",
+    address: "1 Market St, San Francisco, CA",
+    zip_code: "94105",
+    phone: "(415) 555-1001",
+    hours: "Mon-Sat 10am-7pm, Sun 11am-5pm"
+  },
+  {
+    name: "NewTelco San Jose Valley Fair Store",
+    address: "2855 Stevens Creek Blvd, Santa Clara, CA",
+    zip_code: "95050",
+    phone: "(408) 555-2002",
+    hours: "Mon-Sat 10am-8pm, Sun 11am-6pm"
+  },
+  {
+    name: "NewTelco Sacramento Midtown Store",
+    address: "1801 L St, Sacramento, CA",
+    zip_code: "95811",
+    phone: "(916) 555-3003",
+    hours: "Mon-Sat 10am-7pm, Sun 12pm-5pm"
+  },
+  // SoCal
+  {
+    name: "NewTelco Los Angeles Hollywood Store",
+    address: "6801 Hollywood Blvd, Los Angeles, CA",
+    zip_code: "90028",
+    phone: "(323) 555-4004",
+    hours: "Mon-Sat 10am-9pm, Sun 11am-7pm"
+  },
+  {
+    name: "NewTelco San Diego Gaslamp Store",
+    address: "555 5th Ave, San Diego, CA",
+    zip_code: "92101",
+    phone: "(619) 555-5005",
+    hours: "Mon-Sat 10am-8pm, Sun 11am-6pm"
+  },
+  {
+    name: "NewTelco Irvine Spectrum Store",
+    address: "670 Spectrum Center Dr, Irvine, CA",
+    zip_code: "92618",
+    phone: "(949) 555-6006",
+    hours: "Mon-Sat 10am-8pm, Sun 11am-6pm"
+  },
+  // East Coast
+  {
+    name: "NewTelco New York City Midtown Store",
+    address: "350 5th Ave, New York, NY",
+    zip_code: "10118",
+    phone: "(212) 555-7007",
+    hours: "Mon-Sat 9am-8pm, Sun 10am-6pm"
+  },
+  {
+    name: "NewTelco Boston Back Bay Store",
+    address: "800 Boylston St, Boston, MA",
+    zip_code: "02199",
+    phone: "(617) 555-8008",
+    hours: "Mon-Sat 10am-7pm, Sun 12pm-6pm"
+  },
+  {
+    name: "NewTelco Washington DC Georgetown Store",
+    address: "1234 Wisconsin Ave NW, Washington, DC",
+    zip_code: "20007",
+    phone: "(202) 555-9009",
+    hours: "Mon-Sat 10am-7pm, Sun 12pm-5pm"
+  },
+  {
+    name: "NewTelco Miami Beach Store",
+    address: "1601 Collins Ave, Miami Beach, FL",
+    zip_code: "33139",
+    phone: "(305) 555-1010",
+    hours: "Mon-Sat 10am-8pm, Sun 11am-6pm"
+  }
+];

--- a/src/app/agentConfigs/customerServiceWithSupervision/sampleData.ts
+++ b/src/app/agentConfigs/customerServiceWithSupervision/sampleData.ts
@@ -1,0 +1,56 @@
+export const exampleAccountInfo = {
+  accountId: "NT-123456",
+  name: "Alex Johnson",
+  phone: "+1-206-135-1246",
+  email: "alex.johnson@email.com",
+  plan: "Unlimited Plus",
+  balanceDue: "$42.17",
+  lastBillDate: "2024-05-15",
+  lastPaymentDate: "2024-05-20",
+  lastPaymentAmount: "$42.17",
+  status: "Active",
+  address: {
+    street: "1234 Pine St",
+    city: "Seattle",
+    state: "WA",
+    zip: "98101"
+  },
+  lastBillDetails: {
+    basePlan: "$30.00",
+    internationalCalls: "$8.00",
+    dataOverage: "$4.00",
+    taxesAndFees: "$0.17",
+    notes: "Higher than usual due to international calls and data overage."
+  }
+};
+
+export const examplePolicyDocs = [
+  {
+    id: "ID-010",
+    name: "Family Plan Policy",
+    topic: "family plan options",
+    content:
+      "The family plan allows up to 5 lines per account. All lines share a single data pool. Each additional line after the first receives a 10% discount. All lines must be on the same account.",
+  },
+  {
+    id: "ID-020",
+    name: "Promotions and Discounts Policy",
+    topic: "promotions and discounts",
+    content:
+      "The Summer Unlimited Data Sale provides a 20% discount on the Unlimited Plus plan for the first 6 months for new activations completed by July 31, 2024. The Refer-a-Friend Bonus provides a $50 bill credit to both the referring customer and the new customer after 60 days of active service, for activations by August 31, 2024. A maximum of 5 referral credits may be earned per account. Discounts cannot be combined with other offers.",
+  },
+  {
+    id: "ID-030",
+    name: "International Plans Policy",
+    topic: "international plans",
+    content:
+      "International plans are available and include discounted calling, texting, and data usage in over 100 countries.",
+  },
+  {
+    id: "ID-040",
+    name: "Handset Offers Policy",
+    topic: "new handsets",
+    content:
+      "Handsets from brands such as iPhone, Samsung, and Google are available. Special pricing may be available for new activations or upgrades. For current offers, refer to the website or a retail location.",
+  },
+];

--- a/src/app/agentConfigs/customerServiceWithSupervision/supervisorAgent.ts
+++ b/src/app/agentConfigs/customerServiceWithSupervision/supervisorAgent.ts
@@ -28,7 +28,7 @@ You are a helpful customer service agent working for NewTelco, helping a user ef
 - The message is for a voice conversation, so be very concise, use prose, and never create bulleted lists. Prioritize brevity and clarity over completeness.
     - Even if you have access to more information, only mention a couple of the most important items and summarize the rest at a high level.
 - Do not speculate or make assumptions about capabilities or information. If a request cannot be fulfilled with available tools or information, politely refuse and offer to escalate to a human representative.
-- If you lack information needed to use a tool, ask the user for the necessary information before proceeding. Do not call tools with incomplete or null values.
+- If you do not have all required information to call a tool, you MUST ask the user for the missing information in your message. NEVER attempt to call a tool with missing, empty, placeholder, or default values (such as "", "REQUIRED", "null", or similar). Only call a tool when you have all required parameters provided by the user.
 - Do not offer or attempt to fulfill requests for capabilities or services not explicitly supported by your tools or provided information.
 - Only offer to provide more information if you know there is more information available to provide, based on the tools and context you have.
 
@@ -45,6 +45,10 @@ You are a helpful customer service agent working for NewTelco, helping a user ef
 - "To help you with that, I'll just need to verify your information."
 - "Let me check that for you—one moment, please."
 - "I'll retrieve the latest details for you now."
+
+## If required information is missing for a tool call
+- "To help you with that, could you please provide your [required info, e.g., zip code/phone number]?"
+- "I'll need your [required info] to proceed. Could you share that with me?"
 
 # User Message Format
 - Always include your final response to the user.

--- a/src/app/agentConfigs/customerServiceWithSupervision/supervisorAgent.ts
+++ b/src/app/agentConfigs/customerServiceWithSupervision/supervisorAgent.ts
@@ -1,0 +1,237 @@
+import { exampleAccountInfo, examplePolicyDocs } from "./sampleData";
+
+const supervisorAgentInstructions = `You are an expert supervisor agent for customer service, tasked with providing real-time guidance to a more junior agent. You will be given detailed response instructions, tools, and the full conversation history so far.
+
+# Instructions
+- You can provide an answer directly, or call a tool first and then answer the question
+- If you need to call a tool, but don't have the right information, you can tell the junior agent to ask for that information in your message
+- Your message will be read verbatim by the junior agent, so feel free to use it like you would talk directly to the user
+  
+==== Domain-Specific Agent Instructions ====
+You are a helpful customer service agent working for NewTelco, helping a user efficiently fulfill their request while adhering closely to provided guidelines.
+
+# Instructions
+- Always greet the user with "Hi, you've reached NewTelco, how can I help you?"
+- Always call a tool before answering factual questions about the company, its offerings or products, or a user's account. Only use retrieved context and never rely on your own knowledge for any of these questions.
+    - However, if you don't have enough information to properly call the tool, ask the user for the missing information you need before calling the tool. Do not call the tool with null or incomplete values.
+- Escalate to a human if the user requests.
+- Do not discuss prohibited topics (politics, religion, controversial current events, medical, legal, or financial advice, personal conversations, internal company operations, or criticism of any people or company).
+- Rely on sample phrases whenever appropriate, but never repeat a sample phrase in the same conversation. Feel free to vary the sample phrases to avoid sounding repetitive and make it more appropriate for the user.
+- Always follow the provided output format for new messages, including citations for any factual statements from retrieved policy documents.
+
+# Response Instructions
+- Maintain a professional and concise tone in all responses.
+- Respond appropriately given the above guidelines.
+- The message is for a voice conversation, so be very concise, use prose, and never create bulleted lists. Prioritize brevity and clarity over completeness.
+    - Even if you have access to more information, only mention a couple of the most important items and summarize the rest at a high level.
+
+## Additional Guidance on Unsupported Requests
+- Never speculate about specific knowledge, capabilities, or how something might be done. Do not make any assumptions or provide any information beyond a direct refusal and an offer to escalate. This applies even if the capability would logically be possible, like updating account information after reading account information.
+- If a user requests a capability or service (such as making a payment over the phone) that is not explicitly available via your tools or provided information, do not offer or attempt to fulfill the request.
+- Politely inform the user that you are unable to assist with that specific request and offer to escalate to a human representative.
+
+## Offering Next Steps
+- Only offer to provide more information if you know there is more information available to provide, based on the tools and context you have.
+- Only offer to take an action if you know for certain that it is possible to do so, based on your available tools and information. Do not suggest or imply actions that you cannot actually perform.
+
+# Sample Phrases
+## Deflecting a Prohibited Topic
+- "I'm sorry, but I'm unable to discuss that topic. Is there something else I can help you with?"
+- "That's not something I'm able to provide information on, but I'm happy to help with any other questions you may have."
+
+## If you do not have a tool or information to fulfill a request
+- "Sorry, I'm actually not able to do that. Would you like me to transfer you to someone who can help?"
+- "I'm not able to assist with that request. Would you like to speak with a human representative?"
+
+## Before calling a tool
+- "To help you with that, I'll just need to verify your information."
+- "Let me check that for you—one moment, please."
+- "I'll retrieve the latest details for you now."
+
+# User Message Format
+- Always include your final response to the user.
+- When providing factual information from retrieved context, always include citations immediately after the relevant statement(s). Use the following citation format:
+    - For a single source: [NAME](ID)
+    - For multiple sources: [NAME](ID), [NAME](ID)
+- Only provide information about this company, its policies, its products, or the customer's account, and only if it is based on information provided in context. Do not answer questions outside this scope.
+
+# Example (tool call)
+- User: Can you tell me about your family plan options?
+- Supervisor Assistant: lookup_policy_document(topic="family plan options")
+- lookup_policy_document(): [
+  {
+    id: "ID-010",
+    name: "Family Plan Policy",
+    topic: "family plan options",
+    content:
+      "The family plan allows up to 5 lines per account. All lines share a single data pool. Each additional line after the first receives a 10% discount. All lines must be on the same account.",
+  },
+  {
+    id: "ID-011",
+    name: "Unlimited Data Policy",
+    topic: "unlimited data",
+    content:
+      "Unlimited data plans provide high-speed data up to 50GB per month. After 50GB, speeds may be reduced during network congestion. All lines on a family plan share the same data pool. Unlimited plans are available for both individual and family accounts.",
+  },
+];
+- Supervisor Assistant:
+# Message
+Yes we do—up to five lines can share data, and you get a 10% discount for each new line [Family Plan Policy](ID-010).
+
+# Example (Refusal for Unsupported Request)
+- User: Can I make a payment over the phone right now?
+- Supervisor Assistant:
+# Message
+I'm sorry, but I'm not able to process payments over the phone. Would you like me to connect you with a human representative for further assistance?
+`;
+
+const supervisorAgentTools = [
+  {
+    type: "function",
+    function: {
+      name: "lookupPolicyDocument",
+      description:
+        "Tool to look up internal documents and policies by topic or keyword.",
+      parameters: {
+        type: "object",
+        properties: {
+          topic: {
+            type: "string",
+            description:
+              "The topic or keyword to search for in company policies or documents.",
+          },
+        },
+        required: ["topic"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "getUserAccountInfo",
+      description: "Tool to get user account information. This only reads user accounts information, and doesn't provide the ability to modify or delete any values.",
+      parameters: {
+        type: "object",
+        properties: {
+          phone_number: {
+            type: "string",
+            description: "Formatted as '(xxx) xxx-xxxx'. MUST be provided by the user, never a null or empty string.",
+          },
+        },
+        required: ["phone_number"],
+        additionalProperties: false,
+      },
+    },
+  },
+];
+
+async function fetchChatCompletionMessage(body: any) {
+  const response = await fetch("/api/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ ...body, parallel_tool_calls: false }),
+  });
+
+  if (!response.ok) {
+    console.warn("Server returned an error:", response);
+    return { error: "Something went wrong." };
+  }
+
+  const completion = await response.json();
+  return completion.choices[0].message;
+}
+
+function getToolResponse(fName: string) {
+  switch (fName) {
+    case "getUserAccountInfo":
+      return exampleAccountInfo;
+    case "lookupPolicyDocument":
+      return examplePolicyDocs;
+    default:
+      return { result: true };
+  }
+}
+
+async function handleToolCalls(body: any, message: any) {
+  while (message.tool_calls && message.tool_calls.length > 0) {
+    const toolCall = message.tool_calls[0];
+    const fName = toolCall.function.name;
+    console.log(`function, name=${fName}, args=${toolCall.function.arguments}`);
+    const toolRes = getToolResponse(fName);
+    body.messages.push(message);
+    body.messages.push({
+      role: "tool",
+      tool_call_id: toolCall.id,
+      content: JSON.stringify(toolRes),
+    } as any); // hack for tool_call_id param
+    console.log("request after tool call", body);
+    message = await fetchChatCompletionMessage(body);
+    console.log("response after tool call", message);
+    if (message.error) {
+      return { error: "Something went wrong." };
+    }
+  }
+  return message;
+}
+
+function filterTranscriptLogs(transcriptLogs: any[]) {
+  // Remove the first two BREADCRUMB items only
+  let breadcrumbCount = 0;
+  const filtered = [];
+  for (const item of transcriptLogs) {
+    if (item.type === "BREADCRUMB" && breadcrumbCount < 2) {
+      breadcrumbCount++;
+      continue;
+    }
+    if (item.type === "MESSAGE") {
+      // Remove guardrailResult and expanded
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { guardrailResult, expanded, ...rest } = item;
+      filtered.push(rest);
+    } else {
+      filtered.push(item);
+    }
+  }
+  return filtered;
+}
+
+export async function getNextResponse(args: object, transcriptLogs: any[]) {
+  const filteredLogs = filterTranscriptLogs(transcriptLogs);
+
+  const body = {
+    model: "gpt-4.1",
+    messages: [
+      {
+        role: "system",
+        content: supervisorAgentInstructions,
+      },
+      {
+        role: "user",
+        content: `==== Conversation History ====
+    ${JSON.stringify(filteredLogs, null, 2)}`,
+      },
+    ],
+    tools: supervisorAgentTools,
+  };
+
+  console.log("********\ngetnextresponse request", body);
+
+  let message = await fetchChatCompletionMessage(body);
+  console.log("ngetnextresponse response", message);
+  if (message.error) {
+    return { error: "Something went wrong." };
+  }
+
+  // Keep handling tool calls until there are none left
+  while (message.tool_calls && message.tool_calls.length > 0) {
+    message = await handleToolCalls(body, message);
+    if (message.error) {
+      return { error: "Something went wrong." };
+    }
+  }
+
+  return { nextResponse: message.content };
+}

--- a/src/app/agentConfigs/index.ts
+++ b/src/app/agentConfigs/index.ts
@@ -1,11 +1,13 @@
 import { AllAgentConfigsType } from "@/app/types";
 import frontDeskAuthentication from "./frontDeskAuthentication";
 import customerServiceRetail from "./customerServiceRetail";
+import customerServiceWithSupervision from "./customerServiceWithSupervision";
 import simpleExample from "./simpleExample";
 
 export const allAgentSets: AllAgentConfigsType = {
   frontDeskAuthentication,
   customerServiceRetail,
+  customerServiceWithSupervision,
   simpleExample,
 };
 

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -11,8 +11,8 @@ export async function GET() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          // model: "gpt-4o-realtime-preview-2024-12-17",
-          model: "gpt-4o-mini-realtime-preview-2024-12-17",
+          model: "gpt-4o-realtime-preview-2024-12-17",
+          // model: "gpt-4o-mini-realtime-preview-2024-12-17",
         }),
       }
     );

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -11,7 +11,8 @@ export async function GET() {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          model: "gpt-4o-realtime-preview-2024-12-17",
+          // model: "gpt-4o-realtime-preview-2024-12-17",
+          model: "gpt-4o-mini-realtime-preview-2024-12-17",
         }),
       }
     );

--- a/src/app/contexts/TranscriptContext.tsx
+++ b/src/app/contexts/TranscriptContext.tsx
@@ -19,12 +19,15 @@ export const TranscriptProvider: FC<PropsWithChildren> = ({ children }) => {
   const [transcriptItems, setTranscriptItems] = useState<TranscriptItem[]>([]);
 
   function newTimestampPretty(): string {
-    return new Date().toLocaleTimeString([], {
-      hour12: true,
-      hour: "numeric",
+    const now = new Date();
+    const time = now.toLocaleTimeString([], {
+      hour12: false,
+      hour: "2-digit",
       minute: "2-digit",
       second: "2-digit",
     });
+    const ms = now.getMilliseconds().toString().padStart(3, "0");
+    return `${time}.${ms}`;
   }
 
   const addTranscriptMessage: TranscriptContextValue["addTranscriptMessage"] = (itemId, role, text = "", isHidden = false) => {

--- a/src/app/hooks/useHandleServerEvent.ts
+++ b/src/app/hooks/useHandleServerEvent.ts
@@ -81,7 +81,7 @@ export function useHandleServerEvent({
 
     if (currentAgent?.toolLogic?.[functionCallParams.name]) {
       const fn = currentAgent.toolLogic[functionCallParams.name];
-      const fnResult = await fn(args, transcriptItems);
+      const fnResult = await fn(args, transcriptItems, addTranscriptBreadcrumb);
       addTranscriptBreadcrumb(
         `function call result: ${functionCallParams.name}`,
         fnResult

--- a/src/app/lib/callOai.ts
+++ b/src/app/lib/callOai.ts
@@ -8,13 +8,17 @@ export async function runGuardrailClassifier(message: string): Promise<Guardrail
       role: "user",
       content: `You are an expert at classifying text according to moderation policies. Consider the provided message, analyze potential classes from output_classes, and output the best classification. Output json, following the provided schema. Keep your analysis and reasoning short and to the point, maximum 2 sentences.
 
+      <info>
+      - Company name: newTelco
+      </info>
+
       <message>
       ${message}
       </message>
 
       <output_classes>
       - OFFENSIVE: Content that includes hate speech, discriminatory language, insults, slurs, or harassment.
-      - OFF_BRAND: Content that improperly uses TelcoCorp trademarks, discusses competitors like MegaTel or NetCom in any way, or speaks unfavorably about TelcoCorp employees, violating brand guidelines. Should divert discussion back to an approved topic immediately and not invite more discussion.
+      - OFF_BRAND: Content that discusses competitors in a disparaging way.
       - VIOLENCE: Content that includes explicit threats, incitement of harm, or graphic descriptions of physical injury or violence.
       - NONE: If no other classes are appropriate and the message is fine.
       </output_classes>

--- a/src/app/lib/realtimeConnection.ts
+++ b/src/app/lib/realtimeConnection.ts
@@ -37,7 +37,8 @@ export async function createRealtimeConnection(
   await pc.setLocalDescription(offer);
 
   const baseUrl = "https://api.openai.com/v1/realtime";
-  const model = "gpt-4o-realtime-preview-2024-12-17";
+  const model = "gpt-4o-mini-realtime-preview-2024-12-17";
+  // const model = "gpt-4o-realtime-preview-2024-12-17";
 
   const sdpResponse = await fetch(`${baseUrl}?model=${model}`, {
     method: "POST",

--- a/src/app/lib/realtimeConnection.ts
+++ b/src/app/lib/realtimeConnection.ts
@@ -37,8 +37,8 @@ export async function createRealtimeConnection(
   await pc.setLocalDescription(offer);
 
   const baseUrl = "https://api.openai.com/v1/realtime";
-  const model = "gpt-4o-mini-realtime-preview-2024-12-17";
-  // const model = "gpt-4o-realtime-preview-2024-12-17";
+  // const model = "gpt-4o-mini-realtime-preview-2024-12-17";
+  const model = "gpt-4o-realtime-preview-2024-12-17";
 
   const sdpResponse = await fetch(`${baseUrl}?model=${model}`, {
     method: "POST",

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -48,8 +48,9 @@ export interface AgentConfig {
   tools: Tool[];
   toolLogic?: Record<
     string,
-    (args: any, transcriptLogsFiltered: TranscriptItem[]) => Promise<any> | any
+    (args: any, transcriptLogsFiltered: TranscriptItem[], addTranscriptBreadcrumb?: (title: string, data?: any) => void) => Promise<any> | any
   >;
+  // addTranscriptBreadcrumb is a param in case we want to add additional breadcrumbs, e.g. for nested tool calls from a supervisor agent.
   downstreamAgents?:
     | AgentConfig[]
     | { name: string; publicDescription: string }[];


### PR DESCRIPTION
This demonstrates a powerful new pattern with two agents working in tandem:
- Conversation Agent: 4o-realtime, which can take some basic requests and maintain natural conversation flow. Defers all more complex requests to the supervisor agent.
- Supervisor Agent: A fast, smarter text model like GPT-4.1. This model can call tools and formulate correct responses for the conversation agent.

How to use:
1. Add your instructions and tools from your existing text-based agent, ideally which is already performing well with GPT-4.1
2. Opt-in simpler tasks that you'd like the realtime model to take rather than deferring to the supervisor agent. Currently it's set to take basic chitchat, and collecting necessary information for tool calls (which also needs you to add your tools, in yaml to avoid the model trying to call it)


Pros
- Easier devex onramp: You can port your text-based agents very easily, no re-engineering required (the realtime bits are a wrapper and pretty much set)
- Smarter: You get all of the performance of GPT4.1 for tool calling, IF, hallucinations, etc., Most customers agree that our text models are above the bar already
- Cost: Using 4o-mini-realtime + 4.1 should still be cheaper and more performant than 4o-realtime
Cons
- Some UX hit vs. full realtime from the model saying variations of "let me check on that" each time (but IMO it's not that bad, usually 0.5-2s dead time after that before actual response comes through)

<img width="988" alt="image" src="https://github.com/user-attachments/assets/2ea46b4c-6aa2-4f34-82c3-e6b4b2067dc9" />