### PR TITLE
Fix function call extraction to use most recent occurrence

### DIFF
--- a/src/app/hooks/useHandleSessionHistory.ts
+++ b/src/app/hooks/useHandleSessionHistory.ts
@@ -33,7 +33,7 @@ export function useHandleSessionHistory() {
 
   const extractFunctionCallByName = (name: string, content: any[] = []): any => {
     if (!Array.isArray(content)) return undefined;
-    return content.find((c: any) => c.type === 'function_call' && c.name === name);
+    return content.findLast((c: any) => c.type === 'function_call' && c.name === name);
   };
 
   const maybeParseJson = (val: any) => {


### PR DESCRIPTION
  • Changed `find()` to `findLast()` in `extractFunctionCallByName` function to get the most recent function call occurrence
  • This fixes a bug where the function was returning the first occurrence instead of the latest one (it caused the transcript always show call arguments used in the very first function call)
