### PR TITLE
fix: add @modelcontextprotocol/sdk dependency to resolve Next.js buil…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@openai/agents": "^0.0.5",
     "@radix-ui/react-icons": "^1.3.2",
     "dotenv": "^16.4.7",


### PR DESCRIPTION
### Description
This PR fixes a module resolution error that occurs when compiling the Next.js application.

The project currently uses `@openai/agents`, which depends on `@openai/agents-core`. In its internal shims (`shims/mcp-stdio/node.mjs`), there is a dynamic import for `@modelcontextprotocol/sdk/types.js`. 

Since Next.js statically analyzes and traces all imports (including dynamic ones) during the build/dev process, it throws an error and crashes if the module is completely missing from `node_modules`:
`Module not found: Can't resolve '@modelcontextprotocol/sdk/types.js'`

### Changes Made
- Added `@modelcontextprotocol/sdk` as a direct dependency in [package.json](cci:7://file:///g:/NextJs/openai-realtime-agents/package.json:0:0-0:0) to satisfy Next.js webpack module resolution and prevent the dev server from crashing.
