### PR TITLE
Fix simple handoff target name

### DIFF
--- a/src/app/agentConfigs/simpleHandoff.ts
+++ b/src/app/agentConfigs/simpleHandoff.ts
@@ -16,7 +16,7 @@ export const greeterAgent = new RealtimeAgent({
   name: 'greeter',
   voice: 'sage',
   instructions:
-    "Please greet the user and ask them if they'd like a Haiku. If yes, hand off to the 'haiku' agent.",
+    "Please greet the user and ask them if they'd like a Haiku. If yes, hand off to the 'haikuWriter' agent.",
   handoffs: [haikuWriterAgent],
   tools: [],
   handoffDescription: 'Agent that greets the user',


### PR DESCRIPTION
## Summary
- Update the simple handoff greeter instructions to reference the actual downstream `haikuWriter` agent.
- Avoid steering the realtime model toward a nonexistent `haiku` handoff target.

## Validation
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`