### PR TITLE
fix(transcript): correct Next.js client directive (`"use-client"` -> `"use client"`)

### DIFF
--- a/src/app/components/Transcript.tsx
+++ b/src/app/components/Transcript.tsx
@@ -1,4 +1,4 @@
-"use-client";
+"use client";
 
 import React, { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";


### PR DESCRIPTION
Fixes #107.

`src/app/components/Transcript.tsx` starts with:

```ts
"use-client";
```

The Next.js App Router only recognises the exact `"use client"` string directive (space, no hyphen). The hyphenated form is treated as a plain string expression and the file is silently rendered as a Server Component — which is incompatible with this component, since it imports and uses `useEffect`, `useRef`, and `useState`.

The sibling `src/app/components/Events.tsx` in the same directory already uses the correct form (`"use client";`), confirming the intent.

## Change

```diff
-"use-client";
+"use client";
```

One file, one character.

## Verification

`grep -rn '"use-client"' src/` returns 0 matches after the fix; `Events.tsx` and the corrected `Transcript.tsx` are the only two Client Component entrypoints under `src/app/components/`, and now both use the canonical directive.