### PR TITLE
Reset recorded chunks at start of each recording session

### DIFF
--- a/src/app/hooks/useAudioDownload.ts
+++ b/src/app/hooks/useAudioDownload.ts
@@ -13,6 +13,10 @@ function useAudioDownload() {
    * @param remoteStream - The remote MediaStream (e.g., from the audio element).
    */
   const startRecording = async (remoteStream: MediaStream) => {
+    // Reset any chunks left over from a previous session so the new
+    // recording does not get concatenated with the old one on download.
+    recordedChunksRef.current = [];
+
     let micStream: MediaStream;
     try {
       micStream = await navigator.mediaDevices.getUserMedia({ audio: true });


### PR DESCRIPTION
The chunks ref in `useAudioDownload` was only ever appended to, never cleared. When the user disconnects and reconnects the realtime session (which re-triggers `startRecording` via the `sessionStatus` effect in `App.tsx`), the new recording gets concatenated onto chunks from the previous session. Clicking download then produces a WAV containing audio from multiple sessions stitched together.

Fix is to reset `recordedChunksRef.current` to an empty array at the top of `startRecording` so each session starts clean.

Repro:
1. Connect, speak briefly, disconnect.
2. Connect again, speak briefly.
3. Click download.
4. WAV contains both sessions back to back instead of just the latest one.

Verified with `npx tsc --noEmit`, `npm run lint`, and `npm run build`.